### PR TITLE
Workaround for ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/clanactivitytracker/ClanActivityTrackerPlugin.java
+++ b/src/main/java/com/clanactivitytracker/ClanActivityTrackerPlugin.java
@@ -97,19 +97,21 @@ public class ClanActivityTrackerPlugin extends Plugin {
 
 			for (CSVRecord record : records) {
 				// if recorded member is currently online
-				String rsn = record.get(0);
-				if (clanRsns.contains(rsn)) {
-					int index = clanRsns.indexOf(rsn);
-					// update rank and last seen online time
-					csvPrinter.printRecord(rsn,
-							Objects.requireNonNull(clanSettings.titleForRank(memberList.get(index).getRank())).getName(),
-							record.get(2), record.get(3),
-							formatTimestamp((int) Instant.now().getEpochSecond(), "yyyy-MM-dd HH:mm:ss"));
-					updatedRsns.add(rsn);
-				}
-				// if member not currently online, don't change data
-				else {
-					csvPrinter.printRecord(record);
+				if (record.size() == 5) {
+					String rsn = record.get(0);
+					if (clanRsns.contains(rsn)) {
+						int index = clanRsns.indexOf(rsn);
+						// update rank and last seen online time
+						csvPrinter.printRecord(rsn,
+								Objects.requireNonNull(clanSettings.titleForRank(memberList.get(index).getRank())).getName(),
+								record.get(2), record.get(3),
+								formatTimestamp((int) Instant.now().getEpochSecond(), "yyyy-MM-dd HH:mm:ss"));
+						updatedRsns.add(rsn);
+					}
+					// if member not currently online, don't change data
+					else {
+						csvPrinter.printRecord(record);
+					}
 				}
 			}
 			// if online player has not been recorded yet create new entry
@@ -167,16 +169,18 @@ public class ClanActivityTrackerPlugin extends Plugin {
 
 			boolean found = false;
 			for (CSVRecord record : records) {
-				if (rsn.equals(record.get(0))) {
-					// update rank and last seen online time
-					csvPrinter.printRecord(record.get(0),
-							Objects.requireNonNull(clanSettings.titleForRank(event.getClanMember().getRank())).getName(),
-							record.get(2), record.get(3),
-							formatTimestamp((int) Instant.now().getEpochSecond(), "yyyy-MM-dd HH:mm:ss"));
-					found = true;
-				}
-				else {
-					csvPrinter.printRecord(record);
+				if (record.size() == 5) {
+					if (rsn.equals(record.get(0))) {
+						// update rank and last seen online time
+						csvPrinter.printRecord(record.get(0),
+								Objects.requireNonNull(clanSettings.titleForRank(event.getClanMember().getRank())).getName(),
+								record.get(2), record.get(3),
+								formatTimestamp((int) Instant.now().getEpochSecond(), "yyyy-MM-dd HH:mm:ss"));
+						found = true;
+					}
+					else {
+						csvPrinter.printRecord(record);
+					}
 				}
 			}
 			if (!found) {
@@ -224,16 +228,18 @@ public class ClanActivityTrackerPlugin extends Plugin {
 
 			boolean found = false;
 			for (CSVRecord record : records) {
-				if (rsn.equals(record.get(0))) {
-					// update rank and last seen online time
-					csvPrinter.printRecord(record.get(0),
-							event.getMember().getRank(),
-							record.get(2), record.get(3),
-							formatTimestamp((int) Instant.now().getEpochSecond(), "yyyy-MM-dd HH:mm:ss"));
-					found = true;
-				}
-				else {
-					csvPrinter.printRecord(record.get(0), record.get(1), record.get(2), record.get(3), record.get(4));
+				if (record.size() == 5) {
+					if (rsn.equals(record.get(0))) {
+						// update rank and last seen online time
+						csvPrinter.printRecord(record.get(0),
+								event.getMember().getRank(),
+								record.get(2), record.get(3),
+								formatTimestamp((int) Instant.now().getEpochSecond(), "yyyy-MM-dd HH:mm:ss"));
+						found = true;
+					}
+					else {
+						csvPrinter.printRecord(record);
+					}
 				}
 			}
 			if (!found) {
@@ -288,13 +294,15 @@ public class ClanActivityTrackerPlugin extends Plugin {
 						.withHeader(HEADERS));
 
 				for (CSVRecord record : records) {
-					if (record.get("rsn").equals(rsn)) {
-						int newcount = Integer.parseInt(record.get("message count")) + 1;
-						csvPrinter.printRecord(record.get(0), record.get(1), newcount,
-								formatTimestamp(chatMessage.getTimestamp(), "yyyy-MM-dd HH:mm:ss"), record.get(4));
-					}
-					else {
-						csvPrinter.printRecord(record.get(0), record.get(1), record.get(2), record.get(3), record.get(4));
+					if (record.size() == 5) {
+						if (record.get("rsn").equals(rsn)) {
+							int newcount = Integer.parseInt(record.get("message count")) + 1;
+							csvPrinter.printRecord(record.get(0), record.get(1), newcount,
+									formatTimestamp(chatMessage.getTimestamp(), "yyyy-MM-dd HH:mm:ss"), record.get(4));
+						}
+						else {
+							csvPrinter.printRecord(record);
+						}
 					}
 				}
 


### PR DESCRIPTION
Sometimes the tracker stops updating the dates. In these cases I've noticed both for myself as for other users that there is a random number on an otherwise empty line. Most recently from a friend of mine:

![image](https://cdn.discordapp.com/attachments/779907000191942716/1075452187653722235/image.png)

When you delete these lines, the tracker starts working again. I suspect that this number is the messagecount of someone or the messagecount + 1 (aka ``int newcount``). While testing my own plugins I've also noticed that clan-activity-tracker has thrown ``java.lang.ArrayIndexOutOfBoundsException``s. This makes sense, since it's likely trying to get the value for an index that does not exist (e.g. ``record.get(3)`` will result in an ``ArrayIndexOutOfBoundsException`` in the above screenshot).

I've checked the code that should increase the messagecount and that looks fine to me, so I'm not entirely sure what's the cause of these numbers. I've created this workaround so that it ignores the entry unless ``record.size() == 5``. This should prevent any ``ArrayIndexOutOfBoundsException``s.